### PR TITLE
fix: Set gateway o a different way for OpenStack metadata

### DIFF
--- a/pkg/openstack/network.go
+++ b/pkg/openstack/network.go
@@ -68,4 +68,11 @@ type Network struct {
 	IPAddress *string     `json:"ip_address,omitempty"`
 	Netmask   *string     `json:"netmask,omitempty"`
 	Routes    []Route     `json:"routes,omitempty"`
+
+	// Gateway sets the gateway properly even if this flag officially is not
+	// supported if you look into the schema file:
+	//   https://docs.openstack.org/nova/latest/_downloads/9119ca7ac90aa2990e762c08baea3a36/network_data.json
+	// But Cloud-Init does seem to support it, see cloud-init documentation for OpenStack:
+	//   https://github.com/canonical/cloud-init/blob/main/cloudinit/sources/helpers/openstack.py#L576
+	Gateway *string `json:"gateway,omitempty"`
 }

--- a/pkg/sources/openstack.go
+++ b/pkg/sources/openstack.go
@@ -60,11 +60,7 @@ func (m Metadata) OpenStackNetworkData() render.JSON {
 
 			if subnet.Gateway != nil {
 				ip := subnet.Gateway.String()
-				network.Routes = append(network.Routes, openstack.Route{
-					Network: "0.0.0.0",
-					Netmask: "0.0.0.0",
-					Gateway: ip,
-				})
+				network.Gateway = &ip
 			}
 
 			// Add matching routes for the network interface where the gateway is in the subnet


### PR DESCRIPTION
Explanation for that change is https://bugs.launchpad.net/nova/+bug/2117478